### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,20 +13,20 @@ DSFamily_Class	KEYWORD1
 ScanForDevices	KEYWORD2
 ReadDeviceTemp	KEYWORD2
 DeviceStartConvert	KEYWORD2
-Calibrate 	KEYWORD2
-GetDeviceCalibration    KEYWORD2
-SetDeviceCalibration    KEYWORD2
-MinTemperature   	KEYWORD2
-MaxTemperature    	KEYWORD2
-AvgTemperature    	KEYWORD2
-StdDevTemperature    	KEYWORD2
+Calibrate	KEYWORD2
+GetDeviceCalibration	KEYWORD2
+SetDeviceCalibration	KEYWORD2
+MinTemperature	KEYWORD2
+MaxTemperature	KEYWORD2
+AvgTemperature	KEYWORD2
+StdDevTemperature	KEYWORD2
 GetDeviceResolution	KEYWORD2
 SetDeviceResolution	KEYWORD2
 GetDeviceROM	KEYWORD2
 crc8	KEYWORD2
-ThermometersFound    	KEYWORD2
+ThermometersFound	KEYWORD2
 Parasitic	KEYWORD2
-ConversionMillis    	KEYWORD2
+ConversionMillis	KEYWORD2
 
 ########################
 # Constants (LITERAL1) #


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords